### PR TITLE
Fix broken GraphView

### DIFF
--- a/tf-graph/tf-graph-basic.build.html
+++ b/tf-graph/tf-graph-basic.build.html
@@ -1053,4 +1053,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </template>
 </dom-module>
 
-<script src="tf-graph-basic.build.js"></script></body></html>
+<script src="tf-graph-basic.build.js"></script>
+<div style="height:600px">
+  <tf-graph-basic id="custom-graph"></tf-graph-basic>
+</div>
+<script>
+window.onload = (event)=>{
+  document.getElementById("custom-graph").pbtxt = atob(decodeURI(window.location.hash.substr(1)));
+}
+</script>
+</body></html>

--- a/tf-graph/tf-graph-basic.build.js
+++ b/tf-graph/tf-graph-basic.build.js
@@ -38447,7 +38447,7 @@ return this.disabled || !this.required || this.required && this.value;
 Polymer({
 is: 'tf-graph-controls',
 ready: function () {
-d3.select(this.$['summary-icon']).attr('xlink:href', '/files/tf-graph/summary-icon.svg');
+d3.select(this.$['summary-icon']).attr('xlink:href', 'summary-icon.svg');
 },
 properties: {
 hasStats: { type: Boolean },

--- a/tfutils.py
+++ b/tfutils.py
@@ -1,4 +1,5 @@
 import tensorflow as tf
+from tensorflow.core.framework import graph_pb2
 import numpy as np
 from base64 import b64encode
 from IPython.display import clear_output, Image, display, HTML
@@ -15,7 +16,7 @@ def graph_as_HTML(graph_def, baseURL=''):
                 tensor = n.attr['value'].tensor
                 size = len(tensor.tensor_content)
                 if size > max_const_size:
-                    tensor.tensor_content = "<stripped %d bytes>" % size
+                    tensor.tensor_content = "<stripped {} bytes>".format(size).encode()
         return strip_def
 
     def _rename_nodes(graph_def, rename_func):


### PR DESCRIPTION
A common endpoint for viewing graphs in notebooks was: http://tensorboard.appspot.com/tf-graph-basic.build.html

Note that this link is now **dead**! I'm not sure whether this code was modified from appspot app or visa versa, but it it the only living copy of `tf-graph-basic.build.html` I can find. As of recent chrome updates `<link rel=X>` for importing HTML does not work, as such we move the polymer definitions into the file and pass the data as a base64 encoded `location.hash`. This method also allows for hosting the static page off server (work around for coors).

Note that GET requests are limited in size, thus super large graphs will NOT be visible. However, this was more a "trying to figure out what's wrong" rather than a "let's come up with a permanent fix", and meets my purposes.

NOTE: Tensorflow 2 exposes a tensorboard magic that lets you encode an entire tensorboard into a notebook. However this is way better imo (less cluttered, doesn't require a server).